### PR TITLE
Include stddef.h for ptrdiff_t

### DIFF
--- a/m68kmake.c
+++ b/m68kmake.c
@@ -63,6 +63,7 @@ static const char g_version[] = "4.60";
 /* =============================== INCLUDES =============================== */
 /* ======================================================================== */
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/m68kmake.c
+++ b/m68kmake.c
@@ -220,12 +220,12 @@ typedef struct
 /* Function Prototypes */
 void error_exit(const char* fmt, ...);
 void perror_exit(const char* fmt, ...);
-int check_strsncpy(char* dst, char* src, int maxlength);
-int check_atoi(char* str, int *result);
-int skip_spaces(char* str);
+ptrdiff_t check_strsncpy(char* dst, char* src, int maxlength);
+ptrdiff_t check_atoi(char* str, int *result);
+ptrdiff_t skip_spaces(char* str);
 int num_bits(int value);
 int atoh(char* buff);
-int fgetline(char* buff, int nchars, FILE* file);
+size_t fgetline(char* buff, int nchars, FILE* file);
 int get_oper_cycles(opcode_struct* op, int ea_mode, int cpu_type);
 opcode_struct* find_opcode(char* name, int size, char* spec_proc, char* spec_ea);
 opcode_struct* find_illegal_opcode(void);
@@ -503,7 +503,7 @@ void perror_exit(const char* fmt, ...)
 
 
 /* copy until 0 or space and exit with error if we read too far */
-int check_strsncpy(char* dst, char* src, int maxlength)
+ptrdiff_t check_strsncpy(char* dst, char* src, int maxlength)
 {
 	char* p = dst;
 	while(*src && *src != ' ')
@@ -517,7 +517,7 @@ int check_strsncpy(char* dst, char* src, int maxlength)
 }
 
 /* copy until 0 or specified character and exit with error if we read too far */
-int check_strcncpy(char* dst, char* src, char delim, int maxlength)
+ptrdiff_t check_strcncpy(char* dst, char* src, char delim, int maxlength)
 {
 	char* p = dst;
 	while(*src && *src != delim)
@@ -531,7 +531,7 @@ int check_strcncpy(char* dst, char* src, char delim, int maxlength)
 }
 
 /* convert ascii to integer and exit with error if we find invalid data */
-int check_atoi(char* str, int *result)
+ptrdiff_t check_atoi(char* str, int *result)
 {
 	int accum = 0;
 	char* p = str;
@@ -547,7 +547,7 @@ int check_atoi(char* str, int *result)
 }
 
 /* Skip past spaces in a string */
-int skip_spaces(char* str)
+ptrdiff_t skip_spaces(char* str)
 {
 	char* p = str;
 
@@ -590,9 +590,9 @@ int atoh(char* buff)
 }
 
 /* Get a line of text from a file, discarding any end-of-line characters */
-int fgetline(char* buff, int nchars, FILE* file)
+size_t fgetline(char* buff, int nchars, FILE* file)
 {
-	int length;
+	size_t length;
 
 	if(fgets(buff, nchars, file) == NULL)
 		return -1;
@@ -1158,7 +1158,7 @@ void read_insert(char* insert)
 {
 	char* ptr = insert;
 	char* overflow = insert + MAX_INSERT_LENGTH - MAX_LINE_LENGTH;
-	int length;
+	size_t length;
 	char* first_blank = NULL;
 
 	first_blank = NULL;


### PR DESCRIPTION
This is required to get m68kmake to compile on Linux. Presumably on macOS some other header provides the definition of `ptrdiff_t`, so that it compiles without inclusion of the proper header.