### PR TITLE
Add *.d dependency files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ m68kmake
 m68kops.?
 sim
 tags
+*.d


### PR DESCRIPTION
The Makefile in eschaton/MINIXCompat#1 creates .d files for dependency tracking. I added them to .gitignore on the top level, but I guess that does not propagate to the submodules.

Sequenced after #1.